### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '17 2,5,8,11 * * *'
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   automerge:
     uses: oclif/github-workflows/.github/workflows/automerge.yml@main

--- a/.github/workflows/notify-slack-on-pr-open.yml
+++ b/.github/workflows/notify-slack-on-pr-open.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
     branches-ignore: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     uses: oclif/github-workflows/.github/workflows/unitTest.yml@main


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.